### PR TITLE
Fixed external_ids for Card search and database storage

### DIFF
--- a/db/migrate/20230411141721_update_cards_table.rb
+++ b/db/migrate/20230411141721_update_cards_table.rb
@@ -1,5 +1,8 @@
 class UpdateCardsTable < ActiveRecord::Migration[5.2]
-  def change
-		change_column :cards, :external_ids, :integer, array: true, default: [], using: "(string_to_array(external_ids, ','))::integer[]"
+  def up
+    # Change the data type to an array of integers
+    change_column :cards, :external_ids, :integer, array: true, default: []
+
+    # No need for using string_to_array here, as the data type should already be an array of integers
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,9 +19,9 @@ ActiveRecord::Schema.define(version: 2023_04_11_141721) do
     t.string "name", null: false
     t.string "colors", null: false
     t.string "image_urls", null: false
+    t.integer "external_ids", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "external_ids", default: [], array: true
   end
 
   create_table "deck_cards", force: :cascade do |t|


### PR DESCRIPTION
- Corrected `external_ids` column for `cards` to match the **Scryfall API** format of:


PARAMETER | TYPE | ATN | DETAILS
-- | -- | -- | --
:id | Integer |   | The multiverse ID.




